### PR TITLE
Added on_generate listener to generate TARDISes which are in formerly ungenerated chunks.

### DIFF
--- a/demat.lua
+++ b/demat.lua
@@ -1,7 +1,8 @@
 function tardis.demat (owner, name)
 	if owner ~= name then return false, "You don't own that TARDIS!" end
 	local pos = tardis.tardises [owner]["exterior"]
-
+	
+	minetest.forceload_block(pos)
 	minetest.set_node (pos, {name = "tardis:tardis_demat"})
 
 	tardis.tardises [owner]["in_vortex"] = true

--- a/functions.lua
+++ b/functions.lua
@@ -92,3 +92,16 @@ function tardis.set_nav (player, owner)
 		end
 	end)
 end
+
+
+-- When a player teleports into a previously generated mapblock with the TARDIS, we want it to appear.
+minetest.register_on_generated(function(minp, maxp, blockseed)
+	for owner,table in pairs(tardis.tardises) do
+		local exterior = table["exterior"]
+		if exterior.x >= minp.x and exterior.y >= minp.y and exterior.z >= minp.z and
+		   exterior.x <= maxp.x and exterior.y <= maxp.y and exterior.z <= maxp.z then
+			minetest.set_node(exterior, {name="tardis:tardis"})
+			minetest.get_meta(exterior):set_string("owner", owner)
+		end
+	end
+end)

--- a/nodes.lua
+++ b/nodes.lua
@@ -142,5 +142,14 @@ minetest.register_node ("tardis:interior_doors", {
 			player_name = player:get_player_name()
 			minetest.chat_send_player (player_name, "The TARDIS is in the Vortex - the doors have been locked automatically.")
 		end
+	end,
+	
+	on_timer = function (pos)
+		local meta = minetest.get_meta (pos)
+		local owner = meta:get_string ("owner")
+		
+		if tardis.tardises[owner]["in_vortex"] then -- If we're in a vortex, we must have been activated from the remat function.
+			tardis.tardises[owner]["in_vortex"] = false -- exit it.
+		end
 	end
 })

--- a/remat.lua
+++ b/remat.lua
@@ -5,11 +5,12 @@ function tardis.remat (owner, name)
 	else
 		local pos = tardis.tardises [owner]["destination"]
 
-		minetest.forceload_block (pos)
 		minetest.set_node (pos, {name = "tardis:tardis_remat"})
 
 		local meta = minetest.get_meta (pos)
 		meta:set_string ("owner", owner)
+		
+		minetest.get_node_timer(tardis.tardises [owner]["interior"]):start(22.5)
 
 		tardis.tardises [owner]["exterior"] = pos
 		return true
@@ -188,8 +189,6 @@ minetest.register_node ("tardis:tardis_remat_9", {
 
 		local meta = minetest.get_meta (pos)
 		owner = meta:get_string ("owner")
-
-		tardis.tardises [owner]["in_vortex"] = false
 	end ,
 
 	on_construct = function (pos)


### PR DESCRIPTION
Added on_generate listener to generate TARDISes which are in formerly ungenerated chunks. This is so that you don't get locked into the vortex, or stranded without the TARDIS. As a result, I have removed some of the other function calls to forceload_block which aren't necessary anymore and didn't work anyway.